### PR TITLE
Update submodule URLs to use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "pid"]
 	path = pid
-	url = git@github.com:catie-aq/6tron_pid.git
+	url = https://github.com/catie-aq/6tron_pid
 	branch = master
 [submodule "odometry"]
 	path = odometry
-	url = git@github.com:catie-aq/6tron_odometry.git
+	url = https://github.com/catie-aq/6tron_odometry
 	branch = main
 [submodule "mobile-base"]
 	path = mobile-base


### PR DESCRIPTION
This pull request includes updates to the URLs of submodules in the `.gitmodules` file to use HTTPS instead of SSH.

Changes to submodule URLs:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L3-R7): Updated the URL for the `pid` submodule to use HTTPS instead of SSH.
* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L3-R7): Updated the URL for the `odometry` submodule to use HTTPS instead of SSH.

Will close #61